### PR TITLE
refine: Scope Engie suggestions to targeted editor

### DIFF
--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -547,6 +547,7 @@ const DashboardPage = () => {
                 <Card className="flex-1 flex flex-col">
                   <CardContent className="flex-1 flex p-1">
                     <Textarea
+                      id="dashboard-editor-textarea" // Added ID
                       value={text}
                       onChange={handleTextChange}
                       placeholder="Create your first document to get started or select one from the sidebar."
@@ -585,6 +586,7 @@ const DashboardPage = () => {
             onApply={applySuggestion}
             onDismiss={dismissSuggestion}
             onIdeate={() => { /* TODO */ }}
+            targetEditorSelector="#dashboard-editor-textarea" // Added prop
           />
 
           <div className="md:hidden">


### PR DESCRIPTION
This commit refines Engie's suggestion mechanism to differentiate between page-wide analysis and targeted corrections, based on your feedback.

Key changes:

1.  **`targetEditorSelector` Prop (`Engie.tsx`):**
    *   `<Engie />` now accepts an optional `targetEditorSelector` prop to
        identify a specific text editing area on the page.

2.  **Dual Text Extraction (`Engie.tsx`):**
    *   Engie now extracts both full page text (`fullPageText`) and text
        from the element specified by `targetEditorSelector`
        (`targetEditorText`).

3.  **Conditional API Calls (`Engie.tsx`):**
    *   Typo/grammar corrections (`/api/correct-text`) are now *only*
        requested for `targetEditorText`.
    *   Tone analysis (`/api/check-tone`) is performed on `fullPageText`
        to determine `overallPageToneAnalysis`.
    *   If `targetEditorText` is available, a separate tone analysis is
        performed on it to get detailed feedback for the editable content
        (`toneAnalysisResult`).

4.  **Updated UI (`Engie.tsx`):**
    *   The Engie UI now distinguishes between "Overall Page Tone" and
        "Editable Content Analysis" (or "Text Analysis" if no target is set).
    *   Typo suggestions and detailed tone highlights are now correctly
        scoped to the targeted editor's content.

5.  **Integration (`dashboard.tsx`):**
    *   The main textarea on the dashboard page (`src/pages/dashboard.tsx`)
        is now assigned an ID (`dashboard-editor-textarea`).
    *   The `<Engie />` component on the dashboard is configured with
        `targetEditorSelector="#dashboard-editor-textarea"`.

This ensures that while Engie can understand the broader page context for general sentiment, its specific corrective suggestions are focused only on the main text input area, as per your requirements.