### PR TITLE
Fix: Correct middleware cookie handling for mobile login

### DIFF
--- a/src/utils/supabase/middleware.ts
+++ b/src/utils/supabase/middleware.ts
@@ -24,11 +24,7 @@ export const createClient = (request: NextRequest) => {
             value,
             ...options,
           })
-          response = NextResponse.next({
-            request: {
-              headers: request.headers,
-            },
-          })
+          // Ensure response object is not recreated
           response.cookies.set({
             name,
             value,
@@ -42,11 +38,7 @@ export const createClient = (request: NextRequest) => {
             value: '',
             ...options,
           })
-          response = NextResponse.next({
-            request: {
-              headers: request.headers,
-            },
-          })
+          // Ensure response object is not recreated
           response.cookies.set({
             name,
             value: '',
@@ -81,11 +73,7 @@ export async function updateSession(request: NextRequest) {
               value,
               ...options,
             })
-            response = NextResponse.next({
-              request: {
-                headers: request.headers,
-              },
-            })
+            // Ensure response object is not recreated
             response.cookies.set({
               name,
               value,
@@ -98,11 +86,7 @@ export async function updateSession(request: NextRequest) {
               value: '',
               ...options,
             })
-            response = NextResponse.next({
-              request: {
-                headers: request.headers,
-              },
-            })
+            // Ensure response object is not recreated
             response.cookies.set({
               name,
               value: '',


### PR DESCRIPTION
The middleware was previously re-creating the NextResponse object on each cookie operation (set/remove). This could lead to loss of cookie data if multiple cookies were being set by Supabase during authentication, particularly affecting mobile browsers.

This commit refactors the cookie handling in `src/utils/supabase/middleware.ts` to ensure that a single NextResponse object is used and mutated. All cookie operations now correctly apply to this single object, preserving all necessary cookies (e.g., session, refresh token).

This change resolves an issue where you, especially on mobile devices, were unable to log in and access the dashboard because your session cookies were not being set correctly by the middleware after a successful authentication attempt.