### PR TITLE
Fix: Restore drag functionality in Engie component

### DIFF
--- a/src/components/Engie.tsx
+++ b/src/components/Engie.tsx
@@ -145,6 +145,7 @@ const Engie: React.FC<EngieProps> = ({
   const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const prevScannedTextRef = useRef<string>("");
   const inactivityTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const draggableRef = useRef<HTMLDivElement>(null);
 
   // Enhanced state for intelligent features
   const [internalSuggestions, setInternalSuggestions] = useState<Suggestion[]>([]);
@@ -945,8 +946,8 @@ const Engie: React.FC<EngieProps> = ({
       )}
       
       {/* Main Engie Interface */}
-      <Draggable bounds="parent" handle=".handle">
-        <div className={`fixed bottom-5 right-5 flex flex-col items-end z-40 ${isChatOpen ? 'w-80' : 'w-auto'}`}>
+      <Draggable bounds="parent" handle=".handle" nodeRef={draggableRef}>
+        <div ref={draggableRef} className={`fixed bottom-5 right-5 flex flex-col items-end z-40 ${isChatOpen ? 'w-80' : 'w-auto'}`}>
           {/* Notification Badge */}
           {!isChatOpen && (internalSuggestions.length > 0 || insights.some(i => i.priority === 'High' && !i.dismissed)) && (
             <div className="absolute -top-2 -right-2 bg-red-500 text-white text-xs rounded-full w-5 h-5 flex items-center justify-center animate-pulse">


### PR DESCRIPTION
The previous commit afa64c8ee9f8a298548c7a2bb797d45563408ee4 inadvertently broke the dragging capability of the Engie component. This was due to the removal of the `nodeRef` prop from the `<Draggable>` component and its direct child `div`.

This commit re-introduces `nodeRef` by:
1. Creating a `draggableRef` using `useRef<HTMLDivElement>(null)`.
2. Assigning this `draggableRef` to the `nodeRef` prop of the `<Draggable>` component.
3. Assigning this `draggableRef` to the `ref` attribute of the direct child `div` of `<Draggable>`.

This change ensures that `react-draggable` has a stable DOM reference, which is crucial for its operation, especially in environments with React StrictMode, and resolves the inability to drag the component.