### PR TITLE
Fix: Engie modal not opening on mobile tap

### DIFF
--- a/src/components/Engie.tsx
+++ b/src/components/Engie.tsx
@@ -533,7 +533,7 @@ const Engie: React.FC<EngieProps> = ({
   const nodeRef = React.useRef(null);
 
   return (
-    <Draggable handle=".handle" nodeRef={nodeRef}>
+    <Draggable handle=".handle" nodeRef={nodeRef} allowMobileScroll={true}>
       <div ref={nodeRef} id="engie-container" className="fixed bottom-10 right-10 z-50 flex flex-col items-end">
         <AnimatePresence>
           {isChatOpen && (


### PR DESCRIPTION
The Engie modal failed to open when you tapped it on mobile devices. This was due to the `react-draggable` component's default behavior of calling `e.preventDefault()` on `touchstart` events, which prevented the `onClick` event on the Engie button from firing.

The fix involves adding the `allowMobileScroll={true}` prop to the `<Draggable>` component in `Engie.tsx`. This prop instructs `react-draggable` not to call `e.preventDefault()` on `touchstart`, allowing tap/click events to propagate to child elements correctly on mobile devices. This should also ensure that page scrolling remains functional when you interact outside the drag handle.