### PR TITLE
Fix: Engie modal not opening on tap on iPhone Chrome

### DIFF
--- a/src/components/Engie.tsx
+++ b/src/components/Engie.tsx
@@ -533,7 +533,7 @@ const Engie: React.FC<EngieProps> = ({
   const nodeRef = React.useRef(null);
 
   return (
-    <Draggable handle=".handle" nodeRef={nodeRef}>
+    <Draggable handle=".handle" nodeRef={nodeRef} allowMobileScroll={true}>
       <div ref={nodeRef} id="engie-container" className="fixed bottom-10 right-10 z-50 flex flex-col items-end">
         <AnimatePresence>
           {isChatOpen && (
@@ -705,7 +705,7 @@ const Engie: React.FC<EngieProps> = ({
           className="handle relative p-3 rounded-full bg-purple-600 text-white shadow-lg hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-600 focus:ring-opacity-50 cursor-grab"
           whileHover={{ scale: 1.1 }}
           whileTap={{ scale: 0.9, cursor: 'grabbing' }}
-          onClick={() => setIsChatOpen(!isChatOpen)}
+          onTap={(event) => { event.stopPropagation(); setIsChatOpen(!isChatOpen); }}
         >
           { (isScanning || isIdeating) && !isChatOpen ? (
             <Loader2 className="h-8 w-8 animate-spin" />


### PR DESCRIPTION
Previously, the Engie modal would not reliably open when tapped on iPhone Chrome, although it could be dragged. This occurred even after adding `allowMobileScroll={true}` to the parent `react-draggable` component.

The issue was traced to an interaction conflict between `react-draggable` and `framer-motion`'s event handling for the Engie button. The button used `onClick` along with `whileTap` from Framer Motion.

The solution involves two key changes to the `motion.button` within `Engie.tsx`:
1. Replaced the `onClick` handler with Framer Motion's `onTap` gesture handler.
2. Called `event.stopPropagation()` within the `onTap` handler.

This ensures that the tap event is correctly interpreted by Framer Motion for opening the modal and prevents the event from bubbling up to `react-draggable` and being misinterpreted as a drag initiation, which was likely causing the problem on iOS Chrome. The `allowMobileScroll={true}` prop on the `<Draggable>` component remains in place to allow touch events to propagate to child components.

You have confirmed this resolves the tap issue on iPhone Chrome.