### PR TITLE
Fix: Remove @types/next as types are bundled with Next.js 14+

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^30.0.0",
     "@types/lodash.throttle": "^4.1.9",
-    "@types/next": "^14.0.0",
     "@types/node": "^20.19.1",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18",


### PR DESCRIPTION
Removes the `@types/next` dependency from `package.json`.

Next.js versions 10 and later bundle their own TypeScript type definitions. The presence of an explicit `@types/next` package was causing build failures as the specified version `^14.0.0` does not exist in the npm registry for `@types/next` (latest is `9.0.0`).

By removing this unnecessary package, the build should correctly use the types provided by the `next` package itself, which should resolve the `ERR_PNPM_NO_MATCHING_VERSION` error during `pnpm install` on Vercel and also clear up related peer dependency issues.