### PR TITLE
Fix: Ensure text entry box has proper contrast in light and dark modes

### DIFF
--- a/src/styles/enhanced-editor.css
+++ b/src/styles/enhanced-editor.css
@@ -17,7 +17,7 @@
 
 /* Bottom input box - standard styling */
 .main-editor-textarea.enhanced-editor {
-  background-color: white;
+  background-color: var(--input);
   border-radius: 0.5rem;
 }
 


### PR DESCRIPTION
The text entry box (main-editor-textarea) previously had a hardcoded white background. This caused a white-on-white issue in dark mode when the text color inherited the theme's light foreground color.

This commit changes the background-color of the text entry box to use the CSS variable `var(--input)`. This ensures that the background adapts correctly to both light and dark themes, providing appropriate contrast with the text color, which uses `var(--foreground)`.