### PR TITLE
feat: Update part-of-speech highlighting colors

### DIFF
--- a/src/styles/enhanced-editor.css
+++ b/src/styles/enhanced-editor.css
@@ -326,38 +326,68 @@
 
 /* Part of speech colors */
 .pos-noun {
-  background-color: rgba(52, 152, 219, 0.12);
-  border-color: rgba(52, 152, 219, 0.25);
+  background-color: rgba(59, 130, 246, 0.12); /* Blue */
+  border-color: rgba(59, 130, 246, 0.25);
 }
 
 .pos-verb {
-  background-color: rgba(46, 204, 113, 0.12);
-  border-color: rgba(46, 204, 113, 0.25);
+  background-color: rgba(239, 68, 68, 0.12); /* Red */
+  border-color: rgba(239, 68, 68, 0.25);
 }
 
 .pos-adjective {
-  background-color: rgba(155, 89, 182, 0.12);
-  border-color: rgba(155, 89, 182, 0.25);
+  background-color: rgba(16, 185, 129, 0.12); /* Green */
+  border-color: rgba(16, 185, 129, 0.25);
 }
 
 .pos-adverb {
-  background-color: rgba(243, 156, 18, 0.12);
-  border-color: rgba(243, 156, 18, 0.25);
+  background-color: rgba(245, 158, 11, 0.12); /* Amber */
+  border-color: rgba(245, 158, 11, 0.25);
 }
 
 .pos-preposition {
-  background-color: rgba(231, 76, 60, 0.12);
-  border-color: rgba(231, 76, 60, 0.25);
+  background-color: rgba(139, 92, 246, 0.12); /* Purple */
+  border-color: rgba(139, 92, 246, 0.25);
 }
 
 .pos-conjunction {
-  background-color: rgba(22, 160, 133, 0.12);
-  border-color: rgba(22, 160, 133, 0.25);
+  background-color: rgba(236, 72, 153, 0.12); /* Pink */
+  border-color: rgba(236, 72, 153, 0.25);
 }
 
 .pos-article {
-  background-color: rgba(127, 140, 141, 0.12);
-  border-color: rgba(127, 140, 141, 0.25);
+  background-color: rgba(107, 114, 128, 0.12); /* Gray */
+  border-color: rgba(107, 114, 128, 0.25);
+}
+
+.pos-pronoun {
+  background-color: rgba(6, 182, 212, 0.12); /* Cyan */
+  border-color: rgba(6, 182, 212, 0.25);
+}
+
+.pos-interjection {
+  background-color: rgba(249, 115, 22, 0.12); /* Orange */
+  border-color: rgba(249, 115, 22, 0.25);
+}
+
+.pos-determiner {
+  background-color: rgba(132, 204, 22, 0.12); /* Lime */
+  border-color: rgba(132, 204, 22, 0.25);
+}
+
+.pos-punctuation {
+  background-color: rgba(55, 65, 81, 0.12); /* Dark Gray */
+  border-color: rgba(55, 65, 81, 0.25);
+}
+
+.pos-number {
+  background-color: rgba(124, 58, 237, 0.12); /* Violet */
+  border-color: rgba(124, 58, 237, 0.25);
+}
+
+.pos-unknown { /* For Unknown/Other */
+  background-color: rgba(156, 163, 175, 0.12); /* Light Gray */
+  border-color: rgba(156, 163, 175, 0.25);
 }
 
 /* Loading indicator */


### PR DESCRIPTION
I've updated the CSS styles for part-of-speech highlighting in the enhanced editor to match the color legend you provided.

Changes include:
- Modified background and border colors for existing POS classes:
    - Noun: Blue (#3B82F6)
    - Verb: Red (#EF4444)
    - Adjective: Green (#10B981)
    - Adverb: Amber (#F59E0B)
    - Preposition: Purple (#8B5CF6)
    - Conjunction: Pink (#EC4899)
    - Article: Gray (#6B7280)
- Added new CSS classes and styles for additional POS categories from the legend:
    - Pronoun: Cyan (#06B6D4)
    - Interjection: Orange (#F97316)
    - Determiner: Lime (#84CC16)
    - Punctuation: Dark Gray (#374151)
    - Number: Violet (#7C3AED)
    - Unknown/Other: Light Gray (#9CA3AF)

The new colors improve visual distinction and adhere to the specified design requirements. You've confirmed the visual correctness of these changes.