### PR TITLE
Fix Engie visibility issue - remove undefined isVisible check

### DIFF
--- a/src/components/engie/EngieBot.tsx
+++ b/src/components/engie/EngieBot.tsx
@@ -153,8 +153,7 @@ export const EngieBot: React.FC<EngieProps> = (props) => {
   const handleToggleGrokMode = () => controller.toggleGrokMode();
   const handleResearchWithGrok = (topic: string) => controller.researchWithGrok(topic);
 
-  if (!state.isVisible) return null;
-
+  // Engie is always visible - removed visibility check
   return (
     <>
       {/* Engie Container with Relative Positioning */}


### PR DESCRIPTION
- Remove visibility check that was preventing Engie from appearing
- Engie should always be visible as per dashboard comments
- The isVisible property doesn't exist in EngieState interface
- This fixes the issue where Engie disappeared after merge

Fixes: Engie not appearing on dashboard