### PR TITLE
Remove Grok mode toggle button and related UI logic

### DIFF
--- a/src/components/ClientEngie.tsx
+++ b/src/components/ClientEngie.tsx
@@ -17,8 +17,8 @@ interface ClientEngieProps {
   onIdeate: () => void;
   targetEditorSelector?: string;
   documents: Array<{ id: string; title: string }>;
-  grokMode?: boolean;
-  grokPowerRemaining?: number;
+  // grokMode?: boolean; // Removed
+  // grokPowerRemaining?: number; // Removed
 }
 
 const ClientEngie: React.FC<ClientEngieProps> = (props) => {

--- a/src/components/engie/EngieBot.tsx
+++ b/src/components/engie/EngieBot.tsx
@@ -167,6 +167,8 @@ export const EngieBot: React.FC<EngieProps> = (props) => {
 
   // Grok handlers
   const handleSendGrokMessage = async (prompt: string) => {
+    // This method is kept as EngieChatWindow might still have a chat input
+    // if isGrokActive were true (though it won't be with the toggle removed)
     try {
       await controller.sendGrokMessage(prompt);
     } catch (error) {
@@ -174,8 +176,8 @@ export const EngieBot: React.FC<EngieProps> = (props) => {
     }
   };
 
-  const handleToggleGrokMode = () => controller.toggleGrokMode();
-  const handleResearchWithGrok = (topic: string) => controller.researchWithGrok(topic);
+  // const handleToggleGrokMode = () => controller.toggleGrokMode(); // Removed as UI toggle is gone
+  // const handleResearchWithGrok = (topic: string) => controller.researchWithGrok(topic); // Removed as GrokTab UI is gone
 
   return (
     <>
@@ -258,11 +260,11 @@ export const EngieBot: React.FC<EngieProps> = (props) => {
               onManualIdeate={handleManualIdeate}
               onTabChange={handleTabChange}
               formatScore={formatScore}
-              handleToggleGrokMode={handleToggleGrokMode}
-              handleResearchWithGrok={handleResearchWithGrok}
-              onSendGrokMessage={handleSendGrokMessage}
-              grokLoading={false}
-              grokError={null}
+              // handleToggleGrokMode={handleToggleGrokMode} // Removed
+              // handleResearchWithGrok={handleResearchWithGrok} // Removed
+              onSendGrokMessage={handleSendGrokMessage} // Kept: chat input might still render based on isGrokActive
+              grokLoading={false} // Kept: related to onSendGrokMessage
+              grokError={null} // Kept: related to onSendGrokMessage
               popupPosition={popupPosition}
             />
           </motion.div>


### PR DESCRIPTION
This change removes the Grok mode toggle switch from the dashboard and associated client-side logic that enabled it.

- Removed Grok mode state, timer, and handler from DashboardPage.
- Removed Grok mode switch and label from DashboardPage JSX.
- Removed grokMode and grokPowerRemaining props from ClientEngie and EngieBot components.
- Ensured EngieState.isGrokActive defaults to false, effectively disabling UI elements for Grok chat and other Grok features that depended on this state being true via the toggle.

The underlying Grok API service and controller methods for Grok chat remain but will not be triggered from the UI as isGrokActive will always be false.