### PR TITLE
feat: Lock Engie dragging when active suggestions are present

### DIFF
--- a/src/components/engie/EngieBot.tsx
+++ b/src/components/engie/EngieBot.tsx
@@ -30,6 +30,11 @@ export const EngieBot: React.FC<EngieProps> = (props) => {
     return unsubscribe;
   }, [controller]);
 
+  // Update controller when suggestions change
+  useEffect(() => {
+    controller.updateSuggestions(props.suggestions);
+  }, [props.suggestions, controller]);
+
   // Calculate popup position relative to Engie
   const calculatePopupPosition = () => {
     if (!engieRef.current) return 'above';
@@ -184,13 +189,14 @@ export const EngieBot: React.FC<EngieProps> = (props) => {
         onDrag={handleDrag}
         onStart={onStartDrag}
         onStop={onStopDrag}
+        disabled={state.isDragLocked}
       >
         <motion.div
           ref={engieRef}
           className="engie-character cursor-pointer"
           onClick={handleEngieTrigger}
-          whileHover={{ scale: 1.1 }}
-          whileTap={{ scale: 0.95 }}
+          whileHover={{ scale: state.isDragLocked ? 1.0 : 1.1 }}
+          whileTap={{ scale: state.isDragLocked ? 1.0 : 0.95 }}
           style={{
             position: 'fixed',
             left: state.engiePos.x,
@@ -203,7 +209,7 @@ export const EngieBot: React.FC<EngieProps> = (props) => {
             justifyContent: 'center',
             background: 'transparent',
             border: 'none',
-            cursor: 'pointer'
+            cursor: state.isDragLocked ? 'pointer' : 'grab'
           }}
         >
           <AnimatedEngieBot
@@ -212,6 +218,20 @@ export const EngieBot: React.FC<EngieProps> = (props) => {
             direction={state.botDirection}
             emotion={state.botEmotion}
           />
+          
+          {/* Drag Lock Indicator */}
+          {state.isDragLocked && (
+            <motion.div
+              initial={{ opacity: 0, scale: 0.8 }}
+              animate={{ opacity: 1, scale: 1 }}
+              className="absolute -top-2 -left-2"
+              title="Engie is focused on suggestions - complete or dismiss them to unlock dragging"
+            >
+              <div className="w-6 h-6 bg-blue-500 rounded-full flex items-center justify-center">
+                <span className="text-white text-xs">🔒</span>
+              </div>
+            </motion.div>
+          )}
           
           {/* Writing Status Badge */}
           {state.isScanning && (

--- a/src/components/engie/types.ts
+++ b/src/components/engie/types.ts
@@ -66,6 +66,7 @@ export interface EngieState {
   isGrokActive: boolean;
   grokEndTime: number | null;
   grokChatHistory: ChatMessage[];
+  isDragLocked: boolean; // Lock dragging when there are active suggestions
 }
 
 export type BotAnimationState = 'idle' | 'walking';


### PR DESCRIPTION
- Add isDragLocked property to EngieState to track drag lock status
- Lock dragging when there are active suggestions (internal or external)
- Unlock dragging when all suggestions are applied, dismissed, or completed
- Add visual lock indicator (🔒) when Engie is locked to suggestions
- Update cursor and hover behavior based on lock status
- Prevent walk-back behavior when locked to suggestions area
- Add tooltip explaining why Engie is locked

This ensures Engie stays near the suggestions/analyze area when there are active issues to resolve, and only allows free movement when no suggestions are pending.