### PR TITLE
🐛 Fix technical writing prompt state persistence issue

### DIFF
--- a/src/components/InteractiveOnboarding.tsx
+++ b/src/components/InteractiveOnboarding.tsx
@@ -451,6 +451,21 @@ export const InteractiveOnboarding: React.FC<InteractiveOnboardingProps> = ({
   const [openDropdown, setOpenDropdown] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+  // Reset component state when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      // Reset all state to initial values for a fresh start
+      setStep('selection');
+      setWritingMode('professional');
+      setSelectedType(null);
+      setUserText('');
+      setImprovementSuggestion('');
+      setShowEngie(false);
+      setEngieEmotion('excited');
+      setOpenDropdown(null);
+    }
+  }, [isOpen]);
+
   // Auto-focus textarea when writing step starts
   useEffect(() => {
     if (step === 'writing' && textareaRef.current) {


### PR DESCRIPTION
ISSUE: Technical writing flow was breaking after first document creation
- Subsequent document creations skipped prompt and jumped to completion screen
- Component state was persisting between modal open/close cycles

ROOT CAUSE: InteractiveOnboarding component wasn't resetting state on reopen
- step, selectedType, userText, and other state variables retained previous values
- When modal reopened, it started at 'complete' step instead of 'selection'

FIX: Added useEffect hook to reset all component state when isOpen changes
- Resets step to 'selection'
- Clears selectedType, userText, improvementSuggestion
- Resets writingMode to 'professional'
- Ensures clean slate for every new document creation

TESTING:
✅ First document creation works correctly
✅ Subsequent document creations now start fresh at prompt step ✅ All state variables properly reset between sessions ✅ No localStorage/persistent storage issues
✅ Component lifecycle properly managed

The technical writing prompt now provides consistent behavior for all document creation attempts, ensuring users can access the full categorized writing assistance flow every time.