### PR TITLE
🚀 Fix 'Write My Own' flow - add continuation options for custom text

### DIFF
--- a/src/components/InteractiveOnboarding.tsx
+++ b/src/components/InteractiveOnboarding.tsx
@@ -755,6 +755,40 @@ export const InteractiveOnboarding: React.FC<InteractiveOnboardingProps> = ({
                       </Button>
                     </motion.div>
                   )}
+
+                  {/* Continue button for custom text */}
+                  {userText && userText !== selectedType.starterPrompt && userText.trim().length >= 10 && !showEngie && (
+                    <motion.div
+                      initial={{ opacity: 0, y: 10 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      className="flex justify-center gap-3"
+                    >
+                      <Button 
+                        onClick={() => {
+                          const improved = generateImprovement(userText, selectedType);
+                          setImprovementSuggestion(improved);
+                          setShowEngie(true);
+                          setStep('engie-intro');
+                        }}
+                        className="bg-gradient-to-r from-sky-500 to-cyan-500 hover:from-sky-600 hover:to-cyan-600 text-white"
+                      >
+                        <Sparkles className="w-4 h-4 mr-2" />
+                        Get Engie's Help
+                      </Button>
+                      <Button 
+                        variant="outline"
+                        onClick={() => {
+                          setStep('complete');
+                          setTimeout(() => {
+                            onComplete(userText, selectedType?.id || 'general');
+                          }, 1500);
+                        }}
+                        className="border-sky-200 hover:bg-sky-50"
+                      >
+                        Continue Without Help
+                      </Button>
+                    </motion.div>
+                  )}
                 </div>
 
                 <div className="text-xs text-muted-foreground text-center bg-gradient-to-r from-sky-50 to-cyan-50 dark:from-sky-900/20 dark:to-cyan-900/20 p-3 rounded-lg">


### PR DESCRIPTION
ISSUE: Users stuck after writing custom content with no way to proceed
- 'Write my own' button cleared text but provided no advancement mechanism
- Users could type custom content but had no continue/proceed options
- Only auto-trigger at 50+ characters, leaving shorter content stranded

ROOT CAUSE: Missing user control mechanisms for custom text progression
- No manual continue button for user-written content
- No option to skip Engie assistance and proceed directly
- Poor UX for users who prefer shorter content or immediate creation

SOLUTION: Added dual-path progression system
✅ Manual Control Button: 'Get Engie's Help'
- Appears when user has 10+ characters of custom text
- Allows users to manually trigger Engie assistance
- Provides clear call-to-action for progression

✅ Skip Option: 'Continue Without Help'
- Allows users to bypass Engie assistance entirely
- Direct path to document creation for users who prefer independence
- Maintains existing auto-trigger at 50+ characters for convenience

✅ Enhanced UX Flow:
- Write starter prompt → 'Keep this & see magic' OR 'Write my own'
- Write custom content (10+ chars) → 'Get Engie's Help' OR 'Continue Without Help'
- Auto-trigger still works at 50+ characters for seamless experience
- All paths lead to successful document creation

✅ User Choice Accommodation:
- Users who want assistance: Multiple trigger options available
- Users who want independence: Clear skip path provided
- Users who want automation: Existing auto-trigger preserved

TESTING:
✅ Custom text (10+ chars): Both buttons appear correctly ✅ Get Engie's Help: Proceeds to enhancement step
✅ Continue Without Help: Skips to completion and creates document ✅ Auto-trigger (50+ chars): Still works as before
✅ Starter prompt flow: Unchanged and working

The technical writing prompt now provides complete user control over the assistance flow, ensuring no user gets stuck regardless of their content length or assistance preferences.