### PR TITLE
🔧 Fix ESLint build error - escape apostrophe in button text

### DIFF
--- a/src/components/InteractiveOnboarding.tsx
+++ b/src/components/InteractiveOnboarding.tsx
@@ -773,7 +773,7 @@ export const InteractiveOnboarding: React.FC<InteractiveOnboardingProps> = ({
                         className="bg-gradient-to-r from-sky-500 to-cyan-500 hover:from-sky-600 hover:to-cyan-600 text-white"
                       >
                         <Sparkles className="w-4 h-4 mr-2" />
-                        Get Engie's Help
+                                                 Get Engie&apos;s Help
                       </Button>
                       <Button 
                         variant="outline"


### PR DESCRIPTION
ISSUE: Vercel build failing due to unescaped apostrophe
- Error: react/no-unescaped-entities at line 776
- 'Get Engie's Help' button text causing build failure

FIX: Escaped apostrophe with HTML entity
- Changed 'Get Engie's Help' to 'Get Engie&apos;s Help'
- Resolves ESLint react/no-unescaped-entities error
- Maintains identical visual appearance

Build should now pass successfully on Vercel deployment.