### PR TITLE
Refactor: Move EnhancedEditor props destructuring into component body…

### DIFF
--- a/src/components/EnhancedEditor.tsx
+++ b/src/components/EnhancedEditor.tsx
@@ -51,21 +51,26 @@ interface TextHistory {
   scrollPosition: number;
 }
 
-const EnhancedEditor = forwardRef<EnhancedEditorRef, EnhancedEditorProps>(({
-  value,
-  onChange,
-  suggestions,
-  className = '',
-  placeholder = 'Start writing...',
-  toneHighlights = [], // Default to empty array
-  autoAnalyze = true,
-  readOnly = false,
-  showFragments = false,
-  isAnalysisBox = false,
-  reflectTextFrom = '',
-  onSuggestionsFetched,
-  onToneHighlightsFetched
-}, ref) => {
+const EnhancedEditor = forwardRef<EnhancedEditorRef, EnhancedEditorProps>((
+  props: EnhancedEditorProps,
+  ref
+) => {
+  const {
+    value,
+    onChange,
+    suggestions,
+    className = props.className || '',
+    placeholder = props.placeholder || 'Start writing...',
+    toneHighlights = props.toneHighlights || [],
+    autoAnalyze = typeof props.autoAnalyze === 'boolean' ? props.autoAnalyze : true,
+    readOnly = typeof props.readOnly === 'boolean' ? props.readOnly : false,
+    showFragments = typeof props.showFragments === 'boolean' ? props.showFragments : false,
+    isAnalysisBox = typeof props.isAnalysisBox === 'boolean' ? props.isAnalysisBox : false,
+    reflectTextFrom = props.reflectTextFrom || '',
+    onSuggestionsFetched,
+    onToneHighlightsFetched
+  } = props;
+
   const editorRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [highlightedHtml, setHighlightedHtml] = useState<string>('');
@@ -83,7 +88,7 @@ const EnhancedEditor = forwardRef<EnhancedEditorRef, EnhancedEditorProps>(({
   // Add history state for undo/redo functionality
   const [history, setHistory] = useState<TextHistory[]>([]);
   const [historyIndex, setHistoryIndex] = useState<number>(-1);
-  const [maxHistorySize] = useState<number>(50); // Limit history size
+  const maxHistorySize = 50; // Limit history size
   const isUndoRedoOperation = useRef<boolean>(false);
   
   // Countdown timer states


### PR DESCRIPTION
… to simplify signature

This change refactors how props are handled in the EnhancedEditor component. Instead of using inline destructuring with default values directly in the `forwardRef` function signature, the component now accepts a single `props` object. This object is then destructured within the component's body, and default values are applied there.

This is an attempt to resolve a persistent build error where the parser failed to recognize the `forwardRef` expression as a valid initializer, possibly due to the complexity of the original signature.