### PR TITLE
fix: increase demo scenario cycle time to show full suggestions

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -154,11 +154,11 @@ const IndexPage = () => {
     setShowThinking(false);
   }, [selectedWritingType]);
 
-  // Auto-cycle through writing scenarios
+  // Auto-cycle through writing scenarios (increased to allow time for suggestions)
   useEffect(() => {
     const interval = setInterval(() => {
       setSelectedWritingType((prev) => (prev + 1) % writingScenarios.length);
-    }, 8000);
+    }, 12000); // Increased from 8s to 12s to allow full suggestion cycle
     
     return () => clearInterval(interval);
   }, [writingScenarios.length]);


### PR DESCRIPTION
- Increase auto-cycle interval from 8 seconds to 12 seconds
- Allows users to see complete suggestion flow for each scenario:
  - Typing animation: ~3-5 seconds
  - Thinking indicator: 1.2 seconds
  - Suggestion appearance: 1.4 seconds
  - Reading time: ~2-3 seconds
- Prevents LinkedIn Post suggestions from being cut off by GitHub README switch
- Improves user experience by giving adequate time to read Engie's suggestions