### PR TITLE
fix(api): resolve engie-chat endpoint 400 errors and log spam

### DIFF
--- a/src/components/engie/services/EngieApiService.ts
+++ b/src/components/engie/services/EngieApiService.ts
@@ -87,14 +87,15 @@ export class EngieApiService {
       const response = await fetch('/api/engie-chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt, history: currentHistory }),
+        body: JSON.stringify({ message: prompt, history: currentHistory }),
       });
       if (!response.ok) {
-        console.error('Failed to get response from Engie Chat API');
+        const errorText = await response.text();
+        console.error('Failed to get response from Engie Chat API. Status:', response.status, 'Error:', errorText);
         return null;
       }
       const data = await response.json();
-      return data.message || null;
+      return data.reply || null;
     } catch (error) {
       console.error('Error calling Engie Chat API:', error);
       return null;


### PR DESCRIPTION
- Fixed parameter mismatch: send 'message' instead of 'prompt' to match API expectation
- Fixed response field: read 'reply' instead of 'message' from API response
- Enhanced error logging with status codes and response text for better debugging
- Resolves the 400 error spam in production logs